### PR TITLE
Dictionary opds feed

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "core"]
-	path = core
-	url = git@github.com:NYPL-Simplified/server_core.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "core"]
+	path = core
+	url = git@github.com:NYPL-Simplified/server_core.git

--- a/api/controller/dictionary.py
+++ b/api/controller/dictionary.py
@@ -1,19 +1,32 @@
 from nose.tools import set_trace
+from core.util.opds_writer import (
+  OPDSFeed
+)
+from api.opds import DictionaryFeed
 
 class Dictionary(object):
   def __init__(self, external_search, es_url):
     self.external_search = external_search(es_url)
 
-  def definition(self, word, language="English"):
+  def _search(self, word, language):
+    '''Searches ES for definitions based on word and language.
+
+    :param word: word to define
+    :param language: the language of the word
+    :return: a list of definition objects with 'glosses' and 'tags' properties
+    '''
     results = self.external_search.search_for(word, language)
     
     definitions = self.combine_definitions(results)
 
-    return dict(
-      word=word,
-      definitions=definitions,
-    )
+    return definitions
   
+  def definition(self, word, language="English"):
+    definitions = self._search(word, language)
+    feed = DictionaryFeed(word, language)
+
+    return feed.get_feed(definitions)
+
   def combine_definitions(self, words):
     senses = [word['senses'] for word in words]
     definitions = []

--- a/api/opds.py
+++ b/api/opds.py
@@ -1,0 +1,54 @@
+from nose.tools import set_trace
+from core.util.opds_writer import (
+  OPDSFeed
+)
+from flask import url_for
+
+class DictionaryFeed(OPDSFeed):
+
+  def __init__(self, word, language):
+    self.word = word
+    self.language = language
+    # todo: use url_for for this url
+    self.feed = OPDSFeed(
+      title=self.word,
+      url=url_for(
+        "definition",
+        word=word,
+        language=language
+      )
+    )
+
+  def get_feed(self, definitions):
+    self.add_definitions(definitions)
+    return self.feed.feed
+  
+  def add_definitions(self, definitions):
+    '''Adds entries for each definition.
+
+    :param definitions: a list of definition objects with 'glosses' and
+      'tags' properties
+    '''
+    entries = [self.add_entry(definition) for definition in definitions]
+
+  def add_entry(self, definition):
+    '''Adds entries for each definition.
+
+    :param definition: an objects with 'glosses' and 'tags' properties
+    '''
+    elements = []
+
+    for d in definition.get("glosses", []):
+      definition_element = OPDSFeed.makeelement("definition")
+      definition_element.text = d
+      elements.append(definition_element)
+    for t in definition.get("tags", []):
+      tag_element = OPDSFeed.makeelement("tag")
+      tag_element.text = t
+      elements.append(tag_element)
+
+    entry = OPDSFeed.entry(*elements)
+
+    self.feed.feed.append(entry)
+
+    return entry

--- a/api/routes.py
+++ b/api/routes.py
@@ -10,6 +10,9 @@ from api.controller.manager import (
   setup_controllers,
   Manager,
 )
+from core.app_server import (
+  feed_response
+)
 
 @app.before_first_request
 def setup():
@@ -18,8 +21,9 @@ def setup():
 
 @app.route("/<word>/definition/<language>/", methods=["GET"])
 def definition(word, language):
-  definitions = app.manager.dictionary_controller.definition(word, language)
-  return jsonify(definitions)
+  feed = app.manager.dictionary_controller.definition(word, language)
+  
+  return feed_response(feed)
 
 @app.route("/<word>/translation/<language_from>/", methods=["GET"])
 def translation(word, language_from):


### PR DESCRIPTION
Still a WIP and haven't written tests, but this is more to see what is needed from `server_core` to generate OPDS feeds here. It seems what's most needed is `feed_response` from `app_server.py` (and its relevant functions) and the `ODPSFeed` class from `/util/opds_writer.py`.

Besides that, I'm thinking, for now, the feed of a word can be multiple entries of definitions and related tags in a similar format that wiktionary returns. So something like:

```
...
<feed ...>
<id>/cat/definition/english/</id><title>cat</title><updated>2020-02-06T19:53:37Z</updated><link href="/cat/definition/english/" rel="self"/>

...
<entry><definition>A strong tackle used to hoist an anchor to the cathead of a ship.</definition><tag>nautical</tag></entry><entry><definition>Short form of cat-o'-nine-tails.</definition><tag>chiefly</tag><tag>nautical</tag></entry>
...
</feed>
```

But I'm basing that on the entries for `circulation`. Maybe, instead of `entry`, each `definition` element can be one level up and have tags as attributes?